### PR TITLE
Fixes issues with modal children (#302) (#303)

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -36,3 +36,7 @@ export type BulmaComponentWithoutRenderAs<
 > = (
   props: TProps & Omit<ElementProps<TProps, THTMLElement>, 'renderAs'>,
 ) => React.ReactElement;
+
+export type BulmaComponentWithoutModifiers<TProps> = (
+  props: TProps,
+) => React.ReactElement;

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BulmaComponent } from '..';
+import { BulmaComponent, BulmaComponentWithoutModifiers } from '..';
 
 interface ModalProps {
   show?: boolean;
@@ -18,9 +18,7 @@ interface ModalCardHeadProps {
   onClose?: () => void;
 }
 
-export const Modal: (
-  props: ModalProps,
-) => React.ReactElement & {
+export const Modal: BulmaComponentWithoutModifiers<ModalProps> & {
   Content: BulmaComponent<{}, 'div'>;
   Card: BulmaComponent<{}, 'div'> & {
     Head: BulmaComponent<ModalCardHeadProps, 'header'>;


### PR DESCRIPTION
* Revert "Fix missing Modal ts props"

This reverts commit f2e1a0a98d44e8dca0a6fc0cdcced9d9dac6f7f1.

* Update modal types to include document, children, classname